### PR TITLE
Migrate TypeScript code to Rust

### DIFF
--- a/Rust/Cargo.toml
+++ b/Rust/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "3.0"
+regex = "1.5"

--- a/Rust/src/calc_ip.rs
+++ b/Rust/src/calc_ip.rs
@@ -1,0 +1,107 @@
+pub struct CalcIp {
+    ip: u32,
+    subnet: u32,
+    cidr: Option<u8>,
+    network_address: u32,
+    broadcast_address: u32,
+    host_address: u32,
+}
+
+impl CalcIp {
+    pub fn new(ip: &str, subnet: Option<&str>) -> Self {
+        let (ip, subnet, cidr) = if let Some(subnet) = subnet {
+            (Self::parse_ip(ip), Self::parse_subnet(subnet), None)
+        } else {
+            let parts: Vec<&str> = ip.split('/').collect();
+            let ip = Self::parse_ip(parts[0]);
+            let cidr = parts[1].parse::<u8>().unwrap();
+            let subnet = Self::parse_subnet_from_cidr(cidr);
+            (ip, subnet, Some(cidr))
+        };
+
+        let network_address = ip & subnet;
+        let host_address = !subnet;
+        let broadcast_address = network_address | host_address;
+
+        Self {
+            ip,
+            subnet,
+            cidr,
+            network_address,
+            broadcast_address,
+            host_address,
+        }
+    }
+
+    pub fn ip_string(&self) -> String {
+        Self::add_to_dotted_decimal_notation(self.ip)
+    }
+
+    pub fn subnet_string(&self) -> String {
+        Self::add_to_dotted_decimal_notation(self.subnet)
+    }
+
+    pub fn network_address_string(&self) -> String {
+        Self::add_to_dotted_decimal_notation(self.network_address)
+    }
+
+    pub fn get_ip(&self) -> u32 {
+        self.ip
+    }
+
+    pub fn get_subnet(&self) -> u32 {
+        self.subnet
+    }
+
+    pub fn get_cidr(&self) -> Option<u8> {
+        self.cidr
+    }
+
+    pub fn get_network_address(&self) -> u32 {
+        self.network_address
+    }
+
+    pub fn get_broadcast_address(&self) -> u32 {
+        self.broadcast_address
+    }
+
+    pub fn get_host_address(&self) -> u32 {
+        self.host_address
+    }
+
+    fn parse_ip(ip: &str) -> u32 {
+        ip.split('.')
+            .map(|octet| octet.parse::<u32>().unwrap())
+            .enumerate()
+            .fold(0, |acc, (i, octet)| acc + (octet << (8 * (3 - i))))
+    }
+
+    fn parse_subnet(subnet: &str) -> u32 {
+        Self::parse_ip(subnet)
+    }
+
+    fn parse_subnet_from_cidr(cidr: u8) -> u32 {
+        (!0u32) << (32 - cidr)
+    }
+
+    fn add_to_dotted_decimal_notation(ip: u32) -> String {
+        format!(
+            "{}.{}.{}.{}",
+            (ip >> 24) & 0xFF,
+            (ip >> 16) & 0xFF,
+            (ip >> 8) & 0xFF,
+            ip & 0xFF
+        )
+    }
+
+    pub fn get_bin_ip_obj(&self) -> (u32, u32, u32, u32, u32, Option<u8>) {
+        (
+            self.ip,
+            self.subnet,
+            self.network_address,
+            self.broadcast_address,
+            self.host_address,
+            self.cidr,
+        )
+    }
+}

--- a/Rust/src/compare.rs
+++ b/Rust/src/compare.rs
@@ -1,0 +1,69 @@
+pub struct Compare {
+    source: CalcIp,
+    dist: CalcIp,
+    result: ResultType,
+}
+
+impl Compare {
+    pub fn new(source: CalcIp, dist: CalcIp) -> Self {
+        let result = ResultType {
+            source: SourceType {
+                ip: source.ip_string(),
+                subnet: source.subnet_string(),
+                net_addr: source.network_address_string(),
+                other_net_addr: CalcIp::add_to_dotted_decimal_notation(Self::calc_other_net_addr(&source, &dist)),
+            },
+            dist: DistType {
+                ip: dist.ip_string(),
+                subnet: dist.subnet_string(),
+                net_addr: dist.network_address_string(),
+                other_net_addr: CalcIp::add_to_dotted_decimal_notation(Self::calc_other_net_addr(&dist, &source)),
+            },
+            source_to_dist: Self::check_can_reach(&source, &dist),
+            dist_to_source: Self::check_can_reach(&dist, &source),
+        };
+
+        Self { source, dist, result }
+    }
+
+    fn check_can_reach(my_host: &CalcIp, dist_host: &CalcIp) -> bool {
+        if my_host.get_ip() == my_host.get_network_address() || my_host.get_ip() == my_host.get_broadcast_address() {
+            return false;
+        }
+
+        if my_host.get_ip() == dist_host.get_ip() {
+            return false;
+        }
+
+        if my_host.get_network_address() < dist_host.get_ip() && dist_host.get_ip() < my_host.get_broadcast_address() {
+            return true;
+        }
+
+        false
+    }
+
+    fn calc_other_net_addr(my_host: &CalcIp, dist_host: &CalcIp) -> u32 {
+        dist_host.get_ip() & my_host.get_subnet()
+    }
+}
+
+pub struct ResultType {
+    source: SourceType,
+    dist: DistType,
+    source_to_dist: bool,
+    dist_to_source: bool,
+}
+
+pub struct SourceType {
+    ip: String,
+    subnet: String,
+    net_addr: String,
+    other_net_addr: String,
+}
+
+pub struct DistType {
+    ip: String,
+    subnet: String,
+    net_addr: String,
+    other_net_addr: String,
+}

--- a/Rust/src/main.rs
+++ b/Rust/src/main.rs
@@ -1,27 +1,53 @@
+use clap::{App, Arg};
+use regex::Regex;
+
+mod calc_ip;
+mod compare;
+mod output;
+
+use calc_ip::CalcIp;
+use compare::Compare;
+use output::Output;
+
 fn main() {
-    // println!("Hello, world!");
-    // 引数を配列に格納する
-    let args = std::env::args().collect::<Vec<_>>();
+    let matches = App::new("calc-ip-address")
+        .version("1.0")
+        .author("na2na")
+        .about("Calculates IP addresses and subnets")
+        .arg(
+            Arg::with_name("server")
+                .help("Server IP address in CIDR or IP/Subnet format")
+                .required(true)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("client")
+                .help("Client IP address in CIDR or IP/Subnet format")
+                .required(true)
+                .index(2),
+        )
+        .get_matches();
 
-    // 引数を表示する
-    println!("args: {:?}", args);
-    println!("args: {:?}", args[1]);
-    println!("args: {:?}", args[2]);
+    let server_arg = matches.value_of("server").unwrap();
+    let client_arg = matches.value_of("client").unwrap();
 
-    if args.len() < 2 || args.len() > 4 {
-        panic!("正しい表示形式ではありません。CIDR形式と他の形式を混在させることはできません。");
+    let server_ip = parse_ip_arg(server_arg);
+    let client_ip = parse_ip_arg(client_arg);
+
+    let compare = Compare::new(server_ip, client_ip);
+    Output::new(compare.result);
+}
+
+fn parse_ip_arg(arg: &str) -> CalcIp {
+    let cidr_regex = Regex::new(r"^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$").unwrap();
+    let ip_subnet_regex = Regex::new(r"^(\d{1,3}\.){3}\d{1,3} (\d{1,3}\.){3}\d{1,3}$").unwrap();
+
+    if cidr_regex.is_match(arg) {
+        CalcIp::new(arg, None)
+    } else if ip_subnet_regex.is_match(arg) {
+        let parts: Vec<&str> = arg.split_whitespace().collect();
+        CalcIp::new(parts[0], Some(parts[1]))
+    } else {
+        panic!("Invalid IP address format");
     }
-}
-
-struct IpInfo {
-    ip: i32,
-    subnet: i32,
-    cidr: Option<i8>,
-    network_address: i32,
-    broadcast_address: i32,
-    host_address: i32,
-}
-
-impl IpInfo {
-    fn new(ip: String, cidr: Option<String>) {}
 }

--- a/Rust/src/output.rs
+++ b/Rust/src/output.rs
@@ -1,0 +1,62 @@
+pub struct Output;
+
+impl Output {
+    pub fn new(result: ResultType) {
+        println!("サーバ:\t\t{}\t{}", result.source.ip, result.source.subnet);
+        println!("クライアント:\t{}\t{}", result.dist.ip, result.dist.subnet);
+
+        println!(
+            "サーバ視点\t\tサーバNetAddr\t\t{}",
+            if result.source_to_dist {
+                format!("\x1b[32m{}\x1b[0m", result.source.net_addr)
+            } else {
+                format!("\x1b[31m{}\x1b[0m", result.source.net_addr)
+            }
+        );
+
+        println!(
+            "サーバ視点\t\tクライアントNetAddr\t{}",
+            if result.source_to_dist {
+                format!("\x1b[32m{}\x1b[0m", result.source.other_net_addr)
+            } else {
+                format!("\x1b[31m{}\x1b[0m", result.source.other_net_addr)
+            }
+        );
+
+        println!(
+            "サーバ視点\t\tクラアントへ到達が可能\t{}",
+            if result.source_to_dist {
+                "\x1b[32mはい\x1b[0m"
+            } else {
+                "\x1b[31mいいえ\x1b[0m"
+            }
+        );
+
+        println!(
+            "クライアント視点\tサーバNetAddr\t\t{}",
+            if result.dist_to_source {
+                format!("\x1b[32m{}\x1b[0m", result.dist.other_net_addr)
+            } else {
+                format!("\x1b[31m{}\x1b[0m", result.dist.other_net_addr)
+            }
+        );
+
+        println!(
+            "クライアント視点\tクライアントNetAddr\t{}",
+            if result.dist_to_source {
+                format!("\x1b[32m{}\x1b[0m", result.dist.net_addr)
+            } else {
+                format!("\x1b[31m{}\x1b[0m", result.dist.net_addr)
+            }
+        );
+
+        println!(
+            "クライアント視点\tサーバへ到達が可能\t{}",
+            if result.dist_to_source {
+                "\x1b[32mはい\x1b[0m"
+            } else {
+                "\x1b[31mいいえ\x1b[0m"
+            }
+        );
+    }
+}

--- a/Rust/tests/calc_ip_tests.rs
+++ b/Rust/tests/calc_ip_tests.rs
@@ -1,0 +1,71 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calc_ip::CalcIp;
+
+    #[test]
+    fn test_parse_ip() {
+        let ip = "192.168.0.1";
+        let parsed_ip = CalcIp::parse_ip(ip);
+        assert_eq!(parsed_ip, 0xC0A80001);
+    }
+
+    #[test]
+    fn test_parse_subnet() {
+        let subnet = "255.255.255.0";
+        let parsed_subnet = CalcIp::parse_subnet(subnet);
+        assert_eq!(parsed_subnet, 0xFFFFFF00);
+    }
+
+    #[test]
+    fn test_parse_subnet_from_cidr() {
+        let cidr = 24;
+        let parsed_subnet = CalcIp::parse_subnet_from_cidr(cidr);
+        assert_eq!(parsed_subnet, 0xFFFFFF00);
+    }
+
+    #[test]
+    fn test_add_to_dotted_decimal_notation() {
+        let ip = 0xC0A80001;
+        let dotted_decimal = CalcIp::add_to_dotted_decimal_notation(ip);
+        assert_eq!(dotted_decimal, "192.168.0.1");
+    }
+
+    #[test]
+    fn test_get_bin_ip_obj() {
+        let ip = "192.168.0.1";
+        let subnet = "255.255.255.0";
+        let calc_ip = CalcIp::new(ip, Some(subnet));
+        let bin_ip_obj = calc_ip.get_bin_ip_obj();
+        assert_eq!(bin_ip_obj.0, 0xC0A80001);
+        assert_eq!(bin_ip_obj.1, 0xFFFFFF00);
+        assert_eq!(bin_ip_obj.2, 0xC0A80000);
+        assert_eq!(bin_ip_obj.3, 0xC0A800FF);
+        assert_eq!(bin_ip_obj.4, 0xFF);
+        assert_eq!(bin_ip_obj.5, None);
+    }
+
+    #[test]
+    fn test_ip_string() {
+        let ip = "192.168.0.1";
+        let subnet = "255.255.255.0";
+        let calc_ip = CalcIp::new(ip, Some(subnet));
+        assert_eq!(calc_ip.ip_string(), "192.168.0.1");
+    }
+
+    #[test]
+    fn test_subnet_string() {
+        let ip = "192.168.0.1";
+        let subnet = "255.255.255.0";
+        let calc_ip = CalcIp::new(ip, Some(subnet));
+        assert_eq!(calc_ip.subnet_string(), "255.255.255.0");
+    }
+
+    #[test]
+    fn test_network_address_string() {
+        let ip = "192.168.0.1";
+        let subnet = "255.255.255.0";
+        let calc_ip = CalcIp::new(ip, Some(subnet));
+        assert_eq!(calc_ip.network_address_string(), "192.168.0.0");
+    }
+}

--- a/Rust/tests/compare_tests.rs
+++ b/Rust/tests/compare_tests.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calc_ip::CalcIp;
+    use crate::compare::Compare;
+
+    #[test]
+    fn test_check_can_reach() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.1.2/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        assert!(compare.result.source_to_dist);
+        assert!(compare.result.dist_to_source);
+    }
+
+    #[test]
+    fn test_calc_other_net_addr() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.2.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        assert_eq!(compare.result.source.other_net_addr, "192.168.1.0");
+        assert_eq!(compare.result.dist.other_net_addr, "192.168.2.0");
+    }
+
+    #[test]
+    fn test_check_can_reach_with_broadcast_address() {
+        let source_ip = CalcIp::new("192.168.1.255/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        assert!(!compare.result.source_to_dist);
+        assert!(compare.result.dist_to_source);
+    }
+
+    #[test]
+    fn test_check_can_reach_with_network_address() {
+        let source_ip = CalcIp::new("192.168.1.0/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        assert!(!compare.result.source_to_dist);
+        assert!(compare.result.dist_to_source);
+    }
+
+    #[test]
+    fn test_check_can_reach_with_same_ip() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        assert!(!compare.result.source_to_dist);
+        assert!(!compare.result.dist_to_source);
+    }
+}

--- a/Rust/tests/main_tests.rs
+++ b/Rust/tests/main_tests.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+#[test]
+fn test_main_integration() {
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("--")
+        .arg("192.168.1.1/24")
+        .arg("192.168.1.2/24")
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(stderr.is_empty(), "stderr is not empty: {}", stderr);
+    assert!(stdout.contains("サーバ:\t\t192.168.1.1\t255.255.255.0"));
+    assert!(stdout.contains("クライアント:\t192.168.1.2\t255.255.255.0"));
+    assert!(stdout.contains("サーバ視点\t\tサーバNetAddr\t\t\x1b[32m192.168.1.0\x1b[0m"));
+    assert!(stdout.contains("サーバ視点\t\tクライアントNetAddr\t\x1b[32m192.168.1.0\x1b[0m"));
+    assert!(stdout.contains("サーバ視点\t\tクラアントへ到達が可能\t\x1b[32mはい\x1b[0m"));
+    assert!(stdout.contains("クライアント視点\tサーバNetAddr\t\t\x1b[32m192.168.1.0\x1b[0m"));
+    assert!(stdout.contains("クライアント視点\tクライアントNetAddr\t\x1b[32m192.168.1.0\x1b[0m"));
+    assert!(stdout.contains("クライアント視点\tサーバへ到達が可能\t\x1b[32mはい\x1b[0m"));
+}

--- a/Rust/tests/output_tests.rs
+++ b/Rust/tests/output_tests.rs
@@ -1,0 +1,57 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::Output;
+    use crate::compare::{Compare, ResultType, SourceType, DistType};
+    use crate::calc_ip::CalcIp;
+
+    #[test]
+    fn test_output_new() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.1.2/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        let result = compare.result;
+
+        Output::new(result);
+    }
+
+    #[test]
+    fn test_output_new_with_different_subnets() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.2.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        let result = compare.result;
+
+        Output::new(result);
+    }
+
+    #[test]
+    fn test_output_new_with_broadcast_address() {
+        let source_ip = CalcIp::new("192.168.1.255/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        let result = compare.result;
+
+        Output::new(result);
+    }
+
+    #[test]
+    fn test_output_new_with_network_address() {
+        let source_ip = CalcIp::new("192.168.1.0/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        let result = compare.result;
+
+        Output::new(result);
+    }
+
+    #[test]
+    fn test_output_new_with_same_ip() {
+        let source_ip = CalcIp::new("192.168.1.1/24", None);
+        let dist_ip = CalcIp::new("192.168.1.1/24", None);
+        let compare = Compare::new(source_ip, dist_ip);
+        let result = compare.result;
+
+        Output::new(result);
+    }
+}


### PR DESCRIPTION
Translate the TypeScript code to Rust and integrate it into the existing Rust project structure.

* **Add `Rust/src/calc_ip.rs`**: Define `CalcIp` struct and implement methods from `TypeScript/src/modules/CalcIp.ts`.
* **Add `Rust/src/compare.rs`**: Define `Compare` struct and implement methods from `TypeScript/src/modules/Compare.ts`.
* **Add `Rust/src/output.rs`**: Define `Output` struct and implement methods from `TypeScript/src/modules/Output.ts`.
* **Modify `Rust/src/main.rs`**: 
  - Import `CalcIp`, `Compare`, and `Output` modules.
  - Handle command-line arguments and validate input.
  - Instantiate `CalcIp` objects for server and client IPs.
  - Instantiate `Compare` object and pass result to `Output`.
* **Modify `Rust/Cargo.toml`**: Add dependencies for `clap` and `regex` crates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/na2na-p/calc-ip-address?shareId=dd27f1f4-81c4-4adc-a1b2-f0bdad40dfc0).